### PR TITLE
Hash support

### DIFF
--- a/hpfeeds-cif/feedhandler.py
+++ b/hpfeeds-cif/feedhandler.py
@@ -12,28 +12,29 @@ logging.basicConfig(level=logging.DEBUG)
 
 
 def handle_message(msg, host, token, provider, tlp, confidence, tags, group, ssl, include_hp_tags=False):
-    indicator = msg['src_ip']
-    app = msg['app']
-    msg_tags = []
-    if include_hp_tags and msg['tags']:
-        msg_tags = msg['tags']
-    data = {"indicator": indicator,
-            "tlp": tlp,
-            "confidence": confidence,
-            "tags": tags + [app] + msg_tags,
-            "provider": provider,
-            "group": group,
-            "lasttime": datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.%fZ')}
-    logging.debug('Initializing Client instance with: {0}, {1}, {2}'.format(token, host, ssl))
-    cli = Client(token=token,
-                 remote=host,
-                 verify_ssl=ssl)
-    logging.info('Submitting indicator: {0}'.format(data))
-    try:
-      r = cli.indicators_create(json.dumps(data))
-      logging.debug('Indicator submitted with id {}'.format(r))
-    except Exception as e:
-      logging.error('Error submitting indicator: {0}'.format(repr(e)))
+    if msg['signature'] == 'Connection to Honeypot':
+        indicator = msg['src_ip']
+        app = msg['app']
+        msg_tags = []
+        if include_hp_tags and msg['tags']:
+            msg_tags = msg['tags']
+        data = {"indicator": indicator,
+                "tlp": tlp,
+                "confidence": confidence,
+                "tags": tags + [app] + msg_tags,
+                "provider": provider,
+                "group": group,
+                "lasttime": datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.%fZ')}
+        logging.debug('Initializing Client instance with: {0}, {1}, {2}'.format(token, host, ssl))
+        cli = Client(token=token,
+                     remote=host,
+                     verify_ssl=ssl)
+        logging.info('Submitting indicator: {0}'.format(data))
+        try:
+          r = cli.indicators_create(json.dumps(data))
+          logging.debug('Indicator submitted with id {}'.format(r))
+        except Exception as e:
+          logging.error('Error submitting indicator: {0}'.format(repr(e)))
     return
 
 

--- a/hpfeeds-cif/feedhandler.py
+++ b/hpfeeds-cif/feedhandler.py
@@ -28,10 +28,10 @@ def handle_message(msg, host, token, provider, tlp, confidence, tags, group, ssl
     cli = Client(token=token,
                  remote=host,
                  verify_ssl=ssl)
-    logging.debug('Submitting indicator: {0}'.format(data))
+    logging.info('Submitting indicator: {0}'.format(data))
     try:
-      cli.indicators_create(json.dumps(data))
-      logging.debug('Indicator submitted')
+      r = cli.indicators_create(json.dumps(data))
+      logging.debug('Indicator submitted with id {}'.format(r))
     except Exception as e:
       logging.error('Error submitting indicator: {0}'.format(repr(e)))
     return

--- a/hpfeeds-cif/feedhandler.py
+++ b/hpfeeds-cif/feedhandler.py
@@ -12,42 +12,45 @@ logging.basicConfig(level=logging.DEBUG)
 
 
 def handle_message(msg, host, token, provider, tlp, confidence, tags, group, ssl, include_hp_tags=False):
+
+    logging.debug('Found signature: {}'.format(msg['signature']))
+    app = msg['app']
+    msg_tags = []
+    if include_hp_tags and msg['tags']:
+        msg_tags = msg['tags']
+    data = {"tlp": tlp,
+            "confidence": confidence,
+            "tags": tags + [app] + msg_tags,
+            "provider": provider,
+            "group": group,
+            "lasttime": datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.%fZ')}
+
     if msg['signature'] == 'Connection to Honeypot':
         indicator = msg['src_ip']
-        app = msg['app']
-        msg_tags = []
-        if include_hp_tags and msg['tags']:
-            msg_tags = msg['tags']
-        data = {"indicator": indicator,
-                "tlp": tlp,
-                "confidence": confidence,
-                "tags": tags + [app] + msg_tags,
-                "provider": provider,
-                "group": group,
-                "lasttime": datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.%fZ')}
+        data['indicator'] = indicator
         submit_to_cif(data, host, ssl, token)
 
     if msg['signature'] == 'File downloaded on Honeypot':
-        for indicator in [ msg['md5'], msg['sha256'], msg['sha512'] ]:
-            app = msg['app']
-            msg_tags = []
-            if include_hp_tags and msg['tags']:
-                msg_tags = msg['tags']
-            data = {"indicator": indicator,
-                    "tlp": tlp,
-                    "confidence": confidence,
-                    "tags": tags + [app] + msg_tags,
-                    "provider": provider,
-                    "group": group,
-                    "lasttime": datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.%fZ')}
-            submit_to_cif(data, host, ssl, token)
+        for htype in ['md5', 'sha256', 'sha512']:
+            if htype in msg:
+                indicator = msg[htype]
+                rdata = 'Dropped by {}'.format(msg['src_ip'])
+                data['rdata'] = rdata
+                data['indicator'] = indicator
+                submit_to_cif(data, host, ssl, token)
 
+    if msg['signature'] == 'URL download attempted on Honeypot':
+        indicator = msg['url']
+        rdata = 'Dropped by {}'.format(msg['src_ip'])
+        data['rdata'] = rdata
+        data['indicator'] = indicator
+        submit_to_cif(data, host, ssl, token)
 
     return
 
 
 def submit_to_cif(data, host, ssl, token):
-    logging.debug('Initializing Client instance with: {0}, {1}, {2}'.format(token, host, ssl))
+    logging.debug('Initializing Client instance to host={}, with ssl={}'.format(host, ssl))
     cli = Client(token=token,
                  remote=host,
                  verify_ssl=ssl)

--- a/hpfeeds-cif/processors.py
+++ b/hpfeeds-cif/processors.py
@@ -176,7 +176,7 @@ def dionaea_capture(identifier, payload):
         direction='inbound',
         ids_type='network',
         severity='high',
-        signature='Connection to Honeypot',
+        signature='File downloaded on Honeypot',
         url=dec.url,
         md5=dec.md5,
         sha512=dec.sha512,
@@ -281,7 +281,7 @@ def kippo_cowrie_sessions(identifier, payload, name, channel):
     if dec.credentials:
         for username, password in dec.credentials:
             msg = dict(base_message)
-            msg['signature'] = 'SSH login attempted on {} honeypot'.format(name_lower)
+            msg['signature'] = 'SSH login attempted on Honeypot'
             msg['ssh_username'] = username
             msg['ssh_password'] = password
             messages.append(msg)
@@ -289,22 +289,30 @@ def kippo_cowrie_sessions(identifier, payload, name, channel):
     if dec.urls:
         for url in dec.urls:
             msg = dict(base_message)
-            msg['signature'] = 'URL download attempted on {} honeypot'.format(name_lower)
+            msg['signature'] = 'URL download attempted on Honeypot'
             msg['url'] = url
             messages.append(msg)
 
     if dec.commands:
         for command in dec.commands:
             msg = dict(base_message)
-            msg['signature'] = 'command attempted on {} honeypot'.format(name_lower)
+            msg['signature'] = 'command attempted on Honeypot'
             msg['command'] = command
             messages.append(msg)
 
     if dec.unknownCommands:
         for command in dec.unknownCommands:
             msg = dict(base_message)
-            msg['signature'] = 'unknown command attempted on {} honeypot'.format(name_lower)
+            msg['signature'] = 'unknown command attempted on Honeypot'
             msg['command'] = command
+            messages.append(msg)
+
+    if dec.hashes:
+        for fhash in dec.hashes:
+            msg = dict(base_message)
+            msg['signature'] = 'File downloaded on Honeypot'
+            msg['hash'] = fhash
+            msg['sha256'] = fhash
             messages.append(msg)
 
     return messages

--- a/hpfeeds-cif/processors.py
+++ b/hpfeeds-cif/processors.py
@@ -272,7 +272,7 @@ def kippo_cowrie_sessions(identifier, payload, name, channel):
         direction='inbound',
         ids_type='network',
         severity='high',
-        signature='SSH session on {} honeypot'.format(name_lower),
+        signature='Connection to Honeypot',
         ssh_version=dec.version
     )
 
@@ -509,7 +509,7 @@ def wordpot_event(identifier, payload):
         direction='inbound',
         ids_type='network',
         severity='high',
-        signature='Wordpress Exploit, Scan, or Enumeration Attempted',
+        signature='Connection to Honeypot',
         request_url=dec.url,
     )
 
@@ -554,7 +554,7 @@ def shockpot_event(identifier, payload):
         direction='inbound',
         ids_type='network',
         severity='high',
-        signature='Shellshock Exploit Attempted',
+        signature='Connection to Honeypot',
         **kwargs
     )
 
@@ -572,7 +572,7 @@ def elastichoney_events(identifier, payload):
         signature = 'ElasticSearch Exploit Attempted'
     else:
         severity = 'medium'
-        signature = 'ElasticSearch Recon Attempted'
+        signature = 'Connection to Honeypot'
 
     user_agent = ''
     if dec.headers:


### PR DESCRIPTION
Standardizing signature names in this version, adding in message parsing for hashes obtained via cowrie, and initial support for submitting hashes to CIF. Also adjusting submission logic for connections to reduce the number of redundant submissions. Should address #27 .

Also: completely untested so far.