### PR TITLE
Add user defined CIDR range for non-submissions

### DIFF
--- a/hpfeeds-cif.cfg.template
+++ b/hpfeeds-cif.cfg.template
@@ -4,7 +4,6 @@ secret =
 hp_host = localhost
 hp_port = 20000
 channels = amun.events,conpot.events,thug.events,beeswarm.hive,dionaea.capture,thug.files,beeswarn.feeder,cuckoo.analysis,kippo.sessions,cowrie.sessions,glastopf.events,glastopf.files,mwbinary.dionaea.sensorunique,wordpot.events,shockpot.events,p0f.events,suricata.events,elastichoney.events,rdphoney.sessions,uhp.events
-ignore_rfc1918 = false
 include_hp_tags = true
 ignore_cidr = 10.0.0.0/8
 

--- a/hpfeeds-cif.cfg.template
+++ b/hpfeeds-cif.cfg.template
@@ -4,8 +4,9 @@ secret =
 hp_host = localhost
 hp_port = 20000
 channels = amun.events,conpot.events,thug.events,beeswarm.hive,dionaea.capture,thug.files,beeswarn.feeder,cuckoo.analysis,kippo.sessions,cowrie.sessions,glastopf.events,glastopf.files,mwbinary.dionaea.sensorunique,wordpot.events,shockpot.events,p0f.events,suricata.events,elastichoney.events,rdphoney.sessions,uhp.events
-ignore_rfc1918=false
-include_hp_tags=true
+ignore_rfc1918 = false
+include_hp_tags = true
+ignore_cidr = 10.0.0.0/8
 
 [cifv3]
 cif_host = http://cifv3

--- a/hpfeeds-cif.run.j2
+++ b/hpfeeds-cif.run.j2
@@ -33,6 +33,7 @@ then
     sed -i "s/cif_group *=.*/cif_group = ${CIF_GROUP}/g" {{ hpfeeds_cif_dir }}/hpfeeds-cif.cfg
     sed -i "s/cif_verify_ssl *=.*/cif_verify_ssl = ${CIF_VERIFY_SSL}/g" {{ hpfeeds_cif_dir }}/hpfeeds-cif.cfg
     sed -i "s/include_hp_tags *=.*/include_hp_tags = ${INCLUDE_HP_TAGS:-False}/g" {{ hpfeeds_cif_dir }}/hpfeeds-cif.cfg
+    sed -i "s/ignore_cidr *=.*/ignore_cidr = ${IGNORE_CIDR}/g" {{ hpfeeds_cif_dir }}/hpfeeds-cif.cfg
 
     # Generate config file for hpfeeds broker and register
     cd {{ hpfeeds_dir }}/hpfeeds/broker/

--- a/hpfeeds-cif.run.j2
+++ b/hpfeeds-cif.run.j2
@@ -23,7 +23,6 @@ then
     sed -i "s/hp_host *=.*/hp_host = ${HPFEEDS_HOST}/g" {{ hpfeeds_cif_dir }}/hpfeeds-cif.cfg
     sed -i "s/hp_port *=.*/hp_port = ${HPFEEDS_PORT}/g" {{ hpfeeds_cif_dir }}/hpfeeds-cif.cfg
     sed -i "s/channels *=.*/channels = ${CHANNELS}/g" {{ hpfeeds_cif_dir }}/hpfeeds-cif.cfg
-    sed -i "s/ignore_rfc1918 *=.*/ignore_rfc1918 = ${IGNORE_RFC1918:-True}/g" {{ hpfeeds_cif_dir }}/hpfeeds-cif.cfg
     sed -i "s%cif_host *=.*%cif_host = ${CIF_HOST}%g" {{ hpfeeds_cif_dir }}/hpfeeds-cif.cfg
     sed -i "s/cif_token *=.*/cif_token = ${CIF_TOKEN}/g" {{ hpfeeds_cif_dir }}/hpfeeds-cif.cfg
     sed -i "s/cif_provider *=.*/cif_provider = ${CIF_PROVIDER}/g" {{ hpfeeds_cif_dir }}/hpfeeds-cif.cfg

--- a/hpfeeds-cif.run.j2
+++ b/hpfeeds-cif.run.j2
@@ -33,7 +33,7 @@ then
     sed -i "s/cif_group *=.*/cif_group = ${CIF_GROUP}/g" {{ hpfeeds_cif_dir }}/hpfeeds-cif.cfg
     sed -i "s/cif_verify_ssl *=.*/cif_verify_ssl = ${CIF_VERIFY_SSL}/g" {{ hpfeeds_cif_dir }}/hpfeeds-cif.cfg
     sed -i "s/include_hp_tags *=.*/include_hp_tags = ${INCLUDE_HP_TAGS:-False}/g" {{ hpfeeds_cif_dir }}/hpfeeds-cif.cfg
-    sed -i "s/ignore_cidr *=.*/ignore_cidr = ${IGNORE_CIDR}/g" {{ hpfeeds_cif_dir }}/hpfeeds-cif.cfg
+    sed -i "s%ignore_cidr *=.*%ignore_cidr = ${IGNORE_CIDR}%g" {{ hpfeeds_cif_dir }}/hpfeeds-cif.cfg
 
     # Generate config file for hpfeeds broker and register
     cd {{ hpfeeds_dir }}/hpfeeds/broker/

--- a/hpfeeds-cif.sysconfig
+++ b/hpfeeds-cif.sysconfig
@@ -20,7 +20,11 @@ CIF_TAGS='honeypot'
 CIF_GROUP='everyone'
 CIF_VERIFY_SSL=False
 
+# Ignore any RFC1918 (private) address space
 IGNORE_RFC1918=True
+# Optionally, specify CIDR networks for which we should NOT submit CIF indicators
+# Useful for not reporting any locally compromised hosts
+IGNORE_CIDR="192.168.0.0/16,10.0.0.0/8,172.16.0.0/12"
 
 # Include the honeypot specific tags in CIFv3
-INCLUDE_HP_TAGS=True
+INCLUDE_HP_TAGS=False

--- a/hpfeeds-cif.sysconfig
+++ b/hpfeeds-cif.sysconfig
@@ -20,10 +20,8 @@ CIF_TAGS='honeypot'
 CIF_GROUP='everyone'
 CIF_VERIFY_SSL=False
 
-# Ignore any RFC1918 (private) address space
-IGNORE_RFC1918=True
-# Optionally, specify CIDR networks for which we should NOT submit CIF indicators
-# Useful for not reporting any locally compromised hosts
+# Specify CIDR networks for which we should NOT submit CIF indicators
+# Useful for not reporting any locally compromised hosts and prepopulated with RFC1918 addresses
 IGNORE_CIDR="192.168.0.0/16,10.0.0.0/8,172.16.0.0/12"
 
 # Include the honeypot specific tags in CIFv3

--- a/hpfeeds-cif/feedhandler.py
+++ b/hpfeeds-cif/feedhandler.py
@@ -97,7 +97,6 @@ def parse_config(config_file):
     config['hpf_secret'] = parser.get('hpfeeds', 'secret')
     config['hpf_port'] = parser.getint('hpfeeds', 'hp_port')
     config['hpf_host'] = parser.get('hpfeeds', 'hp_host')
-    config['ignore_rfc1918'] = parser.getboolean('hpfeeds', 'ignore_rfc1918')
     config['include_hp_tags'] = parser.getboolean('hpfeeds', 'include_hp_tags')
     config['ignore_cidr'] = parser.get('hpfeeds', 'ignore_cidr')
 
@@ -124,8 +123,9 @@ def main():
     channels = [c.encode('utf-8') for c in config['hpf_feeds']]
     ident = config['hpf_ident'].encode('utf-8')
     secret = config['hpf_secret'].encode('utf-8')
-    ignore_rfc1918 = config['ignore_rfc1918']
     include_hp_tags = config['include_hp_tags']
+    ignore_cidr_l = parse_ignore_cidr_option(config['ignore_cidr'])
+
     cif_token = config['cif_token']
     cif_host = config['cif_host']
     cif_provider = config['cif_provider']
@@ -134,8 +134,6 @@ def main():
     cif_tags = config['cif_tags']
     cif_group = config['cif_group']
     cif_verify_ssl = config['cif_verify_ssl']
-
-    ignore_cidr_l = parse_ignore_cidr_option(config['ignore_cidr'])
 
     processor = processors.HpfeedsMessageProcessor(ignore_cidr_list=ignore_cidr_l)
     logging.debug('Initializing HPFeeds connection with {0}, {1}, {2}, {3}'.format(host,port,ident,secret))
@@ -146,7 +144,7 @@ def main():
         return 1
 
     def on_message(identifier, channel, payload):
-        for msg in processor.process(identifier, channel, payload, ignore_errors=True, ignore_rfc1918=ignore_rfc1918):
+        for msg in processor.process(identifier, channel, payload, ignore_errors=True):
             handle_message(msg, cif_host, cif_token, cif_provider, cif_tlp, cif_confidence,
                            cif_tags, cif_group, cif_verify_ssl, include_hp_tags)
 

--- a/hpfeeds-cif/processors.py
+++ b/hpfeeds-cif/processors.py
@@ -5,6 +5,9 @@ import socket
 import hashlib
 import re
 from IPy import IP
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
 
 IPV6_REGEX = re.compile(r'::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})')
 
@@ -110,7 +113,7 @@ def glastopf_event(identifier, payload):
     try:
         dec = ezdict(json.loads(str(payload)))
     except:
-        print('exception processing glastopf event')
+        logging.warn('exception processing glastopf event')
         traceback.print_exc()
         return None
 
@@ -126,7 +129,7 @@ def glastopf_event(identifier, payload):
             # best of luck!
             request_url = dec['request']['url']
     except:
-        print('exception processing glastopf url, ignoring')
+        logging.warn('exception processing glastopf url, ignoring')
         traceback.print_exc()
 
     tags = []
@@ -155,7 +158,7 @@ def dionaea_capture(identifier, payload):
     try:
         dec = ezdict(json.loads(str(payload)))
     except:
-        print('exception processing dionaea event')
+        logging.warn('exception processing dionaea event')
         traceback.print_exc()
         return
 
@@ -187,7 +190,7 @@ def dionaea_connections(identifier, payload):
     try:
         dec = ezdict(json.loads(str(payload)))
     except:
-        print('exception processing dionaea connection')
+        logging.warn('exception processing dionaea connection')
         traceback.print_exc()
         return
 
@@ -217,7 +220,7 @@ def beeswarm_hive(identifier, payload):
     try:
         dec = ezdict(json.loads(str(payload)))
     except:
-        print('exception processing beeswarm.hive event')
+        logging.warn('exception processing beeswarm.hive event')
         traceback.print_exc()
         return
     return create_message(
@@ -249,7 +252,7 @@ def kippo_cowrie_sessions(identifier, payload, name, channel):
     try:
         dec = ezdict(json.loads(str(payload)))
     except:
-        print('exception processing {} event'.format(name_lower))
+        logging.warn('exception processing {} event'.format(name_lower))
         traceback.print_exc()
         return
 
@@ -332,7 +335,7 @@ def conpot_events(identifier, payload):
         if remote == "127.0.0.1":
             return
     except:
-        print('exception processing conpot event')
+        logging.warn('exception processing conpot event')
         traceback.print_exc()
         return
 
@@ -361,7 +364,7 @@ def snort_alerts(identifier, payload):
     try:
         dec = ezdict(json.loads(str(payload)))
     except:
-        print('exception processing snort alert')
+        logging.warn('exception processing snort alert')
         traceback.print_exc()
         return None
 
@@ -401,7 +404,7 @@ def suricata_events(identifier, payload):
     try:
         dec = ezdict(json.loads(str(payload)))
     except:
-        print('exception processing suricata event')
+        logging.warn('exception processing suricata event')
         traceback.print_exc()
         return None
 
@@ -440,7 +443,7 @@ def p0f_events(identifier, payload):
     try:
         dec = ezdict(json.loads(str(payload)))
     except:
-        print('exception processing suricata event')
+        logging.warn('exception processing suricata event')
         traceback.print_exc()
         return None
     return create_message(
@@ -467,7 +470,7 @@ def amun_events(identifier, payload):
     try:
         dec = ezdict(json.loads(str(payload)))
     except:
-        print('exception processing amun event')
+        logging.warn('exception processing amun event')
         traceback.print_exc()
         return
 
@@ -496,7 +499,7 @@ def wordpot_event(identifier, payload):
     try:
         dec = ezdict(json.loads(str(payload)))
     except:
-        print('exception processing wordpot alert')
+        logging.warn('exception processing wordpot alert')
         traceback.print_exc()
         return
 
@@ -526,7 +529,7 @@ def shockpot_event(identifier, payload):
     try:
         dec = ezdict(json.loads(str(payload)))
     except:
-        print('exception processing shockpot alert')
+        logging.warn('exception processing shockpot alert')
         traceback.print_exc()
         return None
 
@@ -571,7 +574,7 @@ def elastichoney_events(identifier, payload):
     try:
         dec = ezdict(json.loads(str(payload)))
     except:
-        print('exception processing elastichoney alert')
+        logging.warn('exception processing elastichoney alert')
         traceback.print_exc()
         return
 
@@ -621,7 +624,7 @@ def rdphoney_sessions(identifier, payload):
     try:
         dec = ezdict(json.loads(str(payload)))
     except:
-        print('exception processing amun event')
+        logging.warn('exception processing amun event')
         traceback.print_exc()
         return
 
@@ -652,7 +655,7 @@ def uhp_events(identifier, payload):
     try:
         dec = ezdict(json.loads(str(payload)))
     except:
-        print('exception processing amun event')
+        logging.warn('exception processing amun event')
         traceback.print_exc()
         return
 
@@ -708,9 +711,12 @@ class HpfeedsMessageProcessor(object):
     def is_ignore_addr(self,ip):
         try:
             checkip = IP(ip)
-            return True if checkip in self.ignore_cidr_list else False
+            for c in self.ignore_cidr_list:
+                if checkip in c:
+                    return True
+            return False
         except ValueError as e:
-            print('Received invalid IP via hpfeeds: {}'.format(e))
+            logging.warn('Received invalid IP via hpfeeds: {}'.format(e))
             return True
 
     @staticmethod
@@ -741,10 +747,15 @@ class HpfeedsMessageProcessor(object):
                     for msg in message:
                         src_ip = msg.get('src_ip')
                         if not ((ignore_rfc1918 and self.is_rfc1918_addr(src_ip)) or self.is_ignore_addr(src_ip)):
+                            logging.debug('Evaluated ignore_rfc1918: {}, is_rfc1918_addr: {}, is_ignore_addr {} '
+                                          ''.format(ignore_rfc1918,self.is_rfc1918_addr(src_ip),self.is_ignore_addr(src_ip)))
                             results.append(msg)
                 else:
                     src_ip = message.get('src_ip')
                     if not ((ignore_rfc1918 and self.is_rfc1918_addr(src_ip)) or self.is_ignore_addr(src_ip)):
+                        logging.debug('Evaluated ignore_rfc1918: {}, is_rfc1918_addr: {}, is_ignore_addr {} '
+                                      ''.format(ignore_rfc1918, self.is_rfc1918_addr(src_ip),
+                                                self.is_ignore_addr(src_ip)))
                         results.append(message)
         if self.maxmind_geo or self.maxmind_asn:
             self.geo_intelligence_enrichment(results)

--- a/hpfeeds-cif/processors.py
+++ b/hpfeeds-cif/processors.py
@@ -747,16 +747,17 @@ class HpfeedsMessageProcessor(object):
                     for msg in message:
                         src_ip = msg.get('src_ip')
                         if not ((ignore_rfc1918 and self.is_rfc1918_addr(src_ip)) or self.is_ignore_addr(src_ip)):
-                            logging.debug('Evaluated ignore_rfc1918: {}, is_rfc1918_addr: {}, is_ignore_addr {} '
-                                          ''.format(ignore_rfc1918,self.is_rfc1918_addr(src_ip),self.is_ignore_addr(src_ip)))
                             results.append(msg)
+                        else:
+                            logging.debug('Ignored submission for {}: ignore_rfc1918: {}, is_rfc1918_addr: {}, is_ignore_addr {}'.format(src_ip, ignore_rfc1918,self.is_rfc1918_addr(src_ip),self.is_ignore_addr(src_ip)))
+                            continue
                 else:
                     src_ip = message.get('src_ip')
                     if not ((ignore_rfc1918 and self.is_rfc1918_addr(src_ip)) or self.is_ignore_addr(src_ip)):
-                        logging.debug('Evaluated ignore_rfc1918: {}, is_rfc1918_addr: {}, is_ignore_addr {} '
-                                      ''.format(ignore_rfc1918, self.is_rfc1918_addr(src_ip),
-                                                self.is_ignore_addr(src_ip)))
                         results.append(message)
+                    else:
+                        logging.debug('Ignored submission for {}: ignore_rfc1918: {}, is_rfc1918_addr: {}, is_ignore_addr {}'.format(src_ip, ignore_rfc1918, self.is_rfc1918_addr(src_ip), self.is_ignore_addr(src_ip)))
+                        continue
         if self.maxmind_geo or self.maxmind_asn:
             self.geo_intelligence_enrichment(results)
         return results


### PR DESCRIPTION
This PR resolves #26 by adding a user definable varable IGNORE_CIDR, which accepts a comma delimited list of CIDR ranges. When an hpfeeds message is received, the src_ip is checked against this list; if the IP is in the range, the message is ignored, otherwise the message is processed normally.

This PR also removes the original IGNORE_RFC1918 option, in favor of pre-populating the IGNORE_CIDR with the RFC1918 addresses.

While in the code, INCLUDE_HP_TAGS was set to internally default to 'False' and logging was added in a number of locations.