### PR TITLE
Adjust logic of hpfeeds registration to fail early in configuration process. Heroic.

### DIFF
--- a/hpfeeds-cif.run.j2
+++ b/hpfeeds-cif.run.j2
@@ -12,9 +12,20 @@ export $PYTHONPATH
 cd {{ hpfeeds_cif_dir }}
 if [[ ! -f ./hpfeeds-cif.cfg ]]
 then
-    IDENT='hpfeeds-cif'
+    IDENT='hpfeeds-cif-${RANDOM}'
     SECRET=`python -c 'import uuid;print str(uuid.uuid4()).replace("-","")'`
     CHANNELS='amun.events,conpot.events,thug.events,beeswarm.hive,dionaea.capture,dionaea.connections,thug.files,beeswarn.feeder,cuckoo.analysis,kippo.sessions,cowrie.sessions,glastopf.events,glastopf.files,mwbinary.dionaea.sensorunique,snort.alerts,wordpot.events,p0f.events,suricata.events,shockpot.events,elastichoney.events,rdphoney.sessions,uhp.events'
+
+    # Change into the HPFeeds dir, it's needed for hpfeeds scripts
+    pushd {{ hpfeeds_dir }}/hpfeeds/broker/
+
+    # Generate config file for hpfeeds broker and try to register
+    # Exit if failed
+    python {{ hpfeeds_dir }}/hpfeeds/broker/generateconfig.py unattended --mongo_host ${MONGODB_HOST} --mongo_port ${MONGODB_PORT} || exit 1
+    python {{ hpfeeds_dir }}/hpfeeds/broker/add_user.py "$IDENT" "$SECRET" "" "$CHANNELS" || exit 1
+
+    # Change back to {{ hpfeeds_cif_dir }} directory
+    popd
 
     cp ./hpfeeds-cif.cfg.template ./hpfeeds-cif.cfg
 
@@ -34,13 +45,8 @@ then
     sed -i "s/include_hp_tags *=.*/include_hp_tags = ${INCLUDE_HP_TAGS:-False}/g" {{ hpfeeds_cif_dir }}/hpfeeds-cif.cfg
     sed -i "s%ignore_cidr *=.*%ignore_cidr = ${IGNORE_CIDR}%g" {{ hpfeeds_cif_dir }}/hpfeeds-cif.cfg
 
-    # Generate config file for hpfeeds broker and register
-    cd {{ hpfeeds_dir }}/hpfeeds/broker/
-    python {{ hpfeeds_dir }}/hpfeeds/broker/generateconfig.py unattended --mongo_host ${MONGODB_HOST} --mongo_port ${MONGODB_PORT}
-    python {{ hpfeeds_dir }}/hpfeeds/broker/add_user.py "$IDENT" "$SECRET" "" "$CHANNELS"
 fi
 
 cd {{ hpfeeds_cif_dir }}
 echo "Starting hpfeeds cif..."
-
 exec /usr/bin/env python {{ hpfeeds_cif_dir }}/hpfeeds-cif/feedhandler.py {{ hpfeeds_cif_dir }}/hpfeeds-cif.cfg


### PR DESCRIPTION
with previous logic, timing issues in container start could cause container to write out a config that was not successfully registered, and thus always fail when connecting to hpfeeds (which would then cause errors on the hpfeeds side)

Signed-off-by: Jesse Bowling <jesse.bowling@duke.edu>