### PR TITLE
Should resolve issues #33 and #36

### DIFF
--- a/hpfeeds-cif.run.j2
+++ b/hpfeeds-cif.run.j2
@@ -48,5 +48,17 @@ then
 fi
 
 cd {{ hpfeeds_cif_dir }}
+echo "Testing CIF host and key..."
+touch /root/.cif.yml
+cif --ping --token ${CIF_TOKEN} --remote ${CIF_HOST} --no-verify-ssl 2>/dev/null
+if [[ $? -ne 0 ]]
+then
+    echo "Authorization failed; please verify CIF_HOST and CIF_TOKEN, then restart the container."
+    echo "CIF_HOST=${CIF_HOST}"
+    echo "CIF_TOKEN=${CIF_TOKEN}"
+    sleep 86400
+else
+    echo "Successfully pinged CIF host with token"
+fi
 echo "Starting hpfeeds cif..."
 exec /usr/bin/env python {{ hpfeeds_cif_dir }}/hpfeeds-cif/feedhandler.py {{ hpfeeds_cif_dir }}/hpfeeds-cif.cfg

--- a/hpfeeds-cif/feedhandler.py
+++ b/hpfeeds-cif/feedhandler.py
@@ -6,6 +6,7 @@ import hpfeeds
 from ConfigParser import ConfigParser
 import processors
 from cifsdk.client.http import HTTP as Client
+from cifsdk.exceptions import SubmissionFailed
 import logging
 from IPy import IP
 import redis
@@ -121,9 +122,14 @@ def submit_to_cif(data, host, ssl, token, cache):
         cache.setcache(data['indicator'])
         logging.debug('Indicator submitted with id {}'.format(r))
         return True
-    except Exception as e:
-        logging.error('Error submitting indicator: {0}'.format(repr(e)))
-        return False
+    except (SubmissionFailed, Exception) as e:
+        if isinstance(e, SubmissionFailed):
+            logging.error(
+                'Submission failed due to authorization error; please correct your host/key, remove this container, and try again')
+            return False
+        else:
+            logging.error('Error submitting indicator: {} {}'.format(type(e).__name__, e.args))
+            return False
 
 
 def parse_config(config_file):


### PR DESCRIPTION
Adds a startup check of the CIF host and token, and specifically calls out authorization error if there is a failure during submission.

Resolves #33 and #36 

Signed-off-by: Jesse Bowling <jesse.bowling@duke.edu>