### PR TITLE
Allow users to specify which Redis cache database number to use

### DIFF
--- a/hpfeeds-cif.cfg.template
+++ b/hpfeeds-cif.cfg.template
@@ -16,3 +16,4 @@ cif_confidence = 8
 cif_tags = honeypot
 cif_group = everyone
 cif_verify_ssl = False
+cif_cache_db = 2

--- a/hpfeeds-cif.run.j2
+++ b/hpfeeds-cif.run.j2
@@ -47,6 +47,8 @@ sed -i "s/cif_verify_ssl *=.*/cif_verify_ssl = ${CIF_VERIFY_SSL}/g" {{ hpfeeds_c
 sed -i "s/include_hp_tags *=.*/include_hp_tags = ${INCLUDE_HP_TAGS:-False}/g" {{ hpfeeds_cif_dir }}/hpfeeds-cif.cfg
 sed -i "s%ignore_cidr *=.*%ignore_cidr = ${IGNORE_CIDR}%g" {{ hpfeeds_cif_dir }}/hpfeeds-cif.cfg
 
+sed -i "s/cif_cache_db *=.*/cif_cache_db = ${CIF_CACHE_DB:-2}/g" {{ hpfeeds_cif_dir }}/hpfeeds-cif.cfg
+
 cd {{ hpfeeds_cif_dir }}
 echo "Testing CIF host and key..."
 touch /root/.cif.yml
@@ -56,7 +58,8 @@ then
     echo "Authorization failed; please verify CIF_HOST and CIF_TOKEN, then restart the container."
     echo "CIF_HOST=${CIF_HOST}"
     echo "CIF_TOKEN=${CIF_TOKEN}"
-    sleep 86400
+    sleep 300
+    exit 1
 else
     echo "Successfully pinged CIF host with token"
 fi

--- a/hpfeeds-cif.sysconfig
+++ b/hpfeeds-cif.sysconfig
@@ -24,3 +24,8 @@ IGNORE_CIDR="192.168.0.0/16,10.0.0.0/8,172.16.0.0/12"
 
 # Include the honeypot specific tags in CIFv3
 INCLUDE_HP_TAGS=False
+
+# ADVANCED: Specify the Redis database number to use for caching CIF submissions. This is only necessary when
+# running multiple CIF containers on the same host submitting to different instances. Note that hpfeeds-bhr defaults
+# to using database 1 and hpfeeds-cif defaults to using database 2, so generally safe choices are in the range of 3-15.
+# CIF_CACHE_DB=2

--- a/hpfeeds-cif/feedhandler.py
+++ b/hpfeeds-cif/feedhandler.py
@@ -158,6 +158,8 @@ def parse_config(config_file):
     config['cif_group'] = parser.get('cifv3', 'cif_group')
     config['cif_verify_ssl'] = parser.getboolean('cifv3', 'cif_verify_ssl')
 
+    config['cif_cache_db'] = parser.getint('cifv3', 'cif_cache_db')
+
     logging.debug('Parsed config: {0}'.format(repr(config)))
     return config
 
@@ -184,7 +186,9 @@ def main():
     cif_group = config['cif_group']
     cif_verify_ssl = config['cif_verify_ssl']
 
-    cache = RedisCache()
+    cif_cache_db = config['cif_cache_db']
+
+    cache = RedisCache(db=cif_cache_db)
     processor = processors.HpfeedsMessageProcessor(ignore_cidr_list=ignore_cidr_l)
     logging.debug('Initializing HPFeeds connection with {0}, {1}, {2}, {3}'.format(host,port,ident,secret))
     try:


### PR DESCRIPTION
This adds a feature to the sysconfig file allowing for the user to specify which Redis database (0-15) to use to cache for a particular instance. This will allow users to run multiple submission containers and cache independently.