### PR TITLE
Cache expire control

### DIFF
--- a/hpfeeds-cif.cfg.template
+++ b/hpfeeds-cif.cfg.template
@@ -3,7 +3,7 @@ ident =
 secret =
 hp_host = localhost
 hp_port = 20000
-channels = amun.events,conpot.events,thug.events,beeswarm.hive,dionaea.capture,thug.files,beeswarn.feeder,cuckoo.analysis,kippo.sessions,cowrie.sessions,glastopf.events,glastopf.files,mwbinary.dionaea.sensorunique,wordpot.events,shockpot.events,p0f.events,suricata.events,elastichoney.events,rdphoney.sessions,uhp.events
+channels = amun.events,conpot.events,thug.events,beeswarm.hive,dionaea.capture,thug.files,beeswarm.feeder,cuckoo.analysis,kippo.sessions,cowrie.sessions,glastopf.events,glastopf.files,mwbinary.dionaea.sensorunique,wordpot.events,shockpot.events,p0f.events,suricata.events,elastichoney.events,rdphoney.sessions,uhp.events
 include_hp_tags = true
 ignore_cidr = 10.0.0.0/8
 

--- a/hpfeeds-cif.cfg.template
+++ b/hpfeeds-cif.cfg.template
@@ -17,3 +17,4 @@ cif_tags = honeypot
 cif_group = everyone
 cif_verify_ssl = False
 cif_cache_db = 2
+cif_cache_expire = 300

--- a/hpfeeds-cif.run.j2
+++ b/hpfeeds-cif.run.j2
@@ -14,7 +14,7 @@ if [[ ! -f ./hpfeeds-cif.cfg ]]
 then
     IDENT="hpfeeds-cif-${RANDOM}"
     SECRET=`python -c 'import uuid;print str(uuid.uuid4()).replace("-","")'`
-    CHANNELS='amun.events,conpot.events,thug.events,beeswarm.hive,dionaea.capture,dionaea.connections,thug.files,beeswarn.feeder,cuckoo.analysis,kippo.sessions,cowrie.sessions,glastopf.events,glastopf.files,mwbinary.dionaea.sensorunique,snort.alerts,wordpot.events,p0f.events,suricata.events,shockpot.events,elastichoney.events,rdphoney.sessions,uhp.events'
+    CHANNELS='amun.events,conpot.events,thug.events,beeswarm.hive,dionaea.capture,dionaea.connections,thug.files,beeswarm.feeder,cuckoo.analysis,kippo.sessions,cowrie.sessions,glastopf.events,glastopf.files,mwbinary.dionaea.sensorunique,snort.alerts,wordpot.events,p0f.events,suricata.events,shockpot.events,elastichoney.events,rdphoney.sessions,uhp.events'
 
     # Change into the HPFeeds dir, it's needed for hpfeeds scripts
     pushd {{ hpfeeds_dir }}/hpfeeds/broker/

--- a/hpfeeds-cif.run.j2
+++ b/hpfeeds-cif.run.j2
@@ -48,6 +48,7 @@ sed -i "s/include_hp_tags *=.*/include_hp_tags = ${INCLUDE_HP_TAGS:-False}/g" {{
 sed -i "s%ignore_cidr *=.*%ignore_cidr = ${IGNORE_CIDR}%g" {{ hpfeeds_cif_dir }}/hpfeeds-cif.cfg
 
 sed -i "s/cif_cache_db *=.*/cif_cache_db = ${CIF_CACHE_DB:-2}/g" {{ hpfeeds_cif_dir }}/hpfeeds-cif.cfg
+sed -i "s/cif_cache_expire *=.*/cif_cache_expire = ${CIF_CACHE_EXPIRE:-300}/g" {{ hpfeeds_cif_dir }}/hpfeeds-cif.cfg
 
 cd {{ hpfeeds_cif_dir }}
 echo "Testing CIF host and key..."
@@ -58,7 +59,7 @@ then
     echo "Authorization failed; please verify CIF_HOST and CIF_TOKEN, then restart the container."
     echo "CIF_HOST=${CIF_HOST}"
     echo "CIF_TOKEN=${CIF_TOKEN}"
-    sleep 300
+    sleep 120
     exit 1
 else
     echo "Successfully pinged CIF host with token"

--- a/hpfeeds-cif.sysconfig
+++ b/hpfeeds-cif.sysconfig
@@ -28,4 +28,7 @@ INCLUDE_HP_TAGS=False
 # ADVANCED: Specify the Redis database number to use for caching CIF submissions. This is only necessary when
 # running multiple CIF containers on the same host submitting to different instances. Note that hpfeeds-bhr defaults
 # to using database 1 and hpfeeds-cif defaults to using database 2, so generally safe choices are in the range of 3-15.
+#
+# The CIF_CACHE_EXPIRE variable specifies how many seconds to cache an IP before re-submitting it to the CIF instance.
 # CIF_CACHE_DB=2
+# CIF_CACHE_EXPIRE=300

--- a/hpfeeds-cif/feedhandler.py
+++ b/hpfeeds-cif/feedhandler.py
@@ -159,6 +159,7 @@ def parse_config(config_file):
     config['cif_verify_ssl'] = parser.getboolean('cifv3', 'cif_verify_ssl')
 
     config['cif_cache_db'] = parser.getint('cifv3', 'cif_cache_db')
+    config['cif_cache_expire'] = parser.getint('cifv3', 'cif_cache_expire')
 
     logging.debug('Parsed config: {0}'.format(repr(config)))
     return config

--- a/hpfeeds-cif/feedhandler.py
+++ b/hpfeeds-cif/feedhandler.py
@@ -19,11 +19,11 @@ class RedisCache(object):
     Implement a simple cache using Redis.
     '''
 
-    def __init__(self, host='redis', port=6379, db=2):
+    def __init__(self, host='redis', port=6379, db=2, expire=300):
         # This code will have implication of no more than one instance of BHR
         # In case of multiples, false cache hits will result due to db selected
         self.r = redis.Redis(host=host, port=port, db=db)
-        self.expire_t = 60
+        self.expire_t = expire
 
     def iscached(self,ip):
         a = self.r.get(ip)
@@ -187,8 +187,9 @@ def main():
     cif_verify_ssl = config['cif_verify_ssl']
 
     cif_cache_db = config['cif_cache_db']
+    cif_cache_expire = config['cif_cache_expire']
 
-    cache = RedisCache(db=cif_cache_db)
+    cache = RedisCache(db=cif_cache_db, expire=cif_cache_expire)
     processor = processors.HpfeedsMessageProcessor(ignore_cidr_list=ignore_cidr_l)
     logging.debug('Initializing HPFeeds connection with {0}, {1}, {2}, {3}'.format(host,port,ident,secret))
     try:


### PR DESCRIPTION
This PR exposes the CIF cache timeout as a user configurable variable. It also sets the default timeout from 60 seconds to 300 seconds.

Also includes a "beeswarn" spelling correction and reduces the restart time on CIF key failure from 5 minutes to 2 minutes.